### PR TITLE
[🐸 Frogbot] Update Maven dependencies

### DIFF
--- a/multi1/pom.xml
+++ b/multi1/pom.xml
@@ -51,13 +51,13 @@
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-email</artifactId>
-            <version>1.1</version>
+            <version>1.5</version>
             <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>org.codehaus.plexus</groupId>
             <artifactId>plexus-utils</artifactId>
-            <version>1.5.1</version>
+            <version>3.0.24</version>
         </dependency>
         <dependency>
             <groupId>javax.servlet.jsp</groupId>
@@ -68,7 +68,7 @@
         <dependency>
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
-            <version>1.4</version>
+            <version>2.7</version>
         </dependency>
         <dependency>
             <groupId>org.springframework</groupId>


### PR DESCRIPTION
<div align='center'>

[![🚨 This automated pull request was created by Frogbot and fixes the below:](https://raw.githubusercontent.com/jfrog/frogbot/master/resources/v2/vulnerabilitiesFixBannerPR.png)](https://docs.jfrog-applications.jfrog.io/jfrog-applications/frogbot)

</div>


## 📦 Vulnerable Dependencies
### ✍️ Summary
<div align='center'>

| SEVERITY                | CONTEXTUAL ANALYSIS                  | DIRECT DEPENDENCIES                  | IMPACTED DEPENDENCY                  | FIXED VERSIONS                  | CVES                  |
| :---------------------: | :-----------------------------------: | :-----------------------------------: | :-----------------------------------: | :-----------------------------------: | :-----------------------------------: |
| ![](https://raw.githubusercontent.com/jfrog/frogbot/master/resources/v2/applicableHighSeverity.png)<br>    High | Undetermined | org.apache.commons:commons-email:1.1<br>org.jfrog.test:multi1:3.7-SNAPSHOT | org.apache.commons:commons-email 1.1 | [1.5] | CVE-2018-1294 |
| ![](https://raw.githubusercontent.com/jfrog/frogbot/master/resources/v2/applicableMediumSeverity.png)<br>  Medium | Undetermined | commons-io:commons-io:1.4<br>org.jfrog.test:multi1:3.7-SNAPSHOT | commons-io:commons-io 1.4 | [2.7] | CVE-2021-29425 |
| ![](https://raw.githubusercontent.com/jfrog/frogbot/master/resources/v2/applicableCriticalSeverity.png)<br>Critical | Undetermined | org.codehaus.plexus:plexus-utils:1.5.1<br>org.jfrog.test:multi1:3.7-SNAPSHOT | org.codehaus.plexus:plexus-utils 1.5.1 | [3.0.16] | CVE-2017-1000487 |

</div>

<details>
<summary> <b>🔬 Research Details</b> </summary>
<br>

<details>
<summary> <b>[ CVE-2018-1294 ] org.apache.commons:commons-email 1.1</b> </summary>
<br>


**Description:**
If a user of Apache Commons Email (typically an application programmer) passes unvalidated input as the so-called "Bounce Address", and that input contains line-breaks, then the email details (recipients, contents, etc.) might be manipulated. Mitigation: Users should upgrade to Commons-Email 1.5. You can mitigate this vulnerability for older versions of Commons Email by stripping line-breaks from data, that will be passed to Email.setBounceAddress(String).

</details>

<details>
<summary> <b>[ CVE-2021-29425 ] commons-io:commons-io 1.4</b> </summary>
<br>


**Description:**
In Apache Commons IO before 2.7, When invoking the method FileNameUtils.normalize with an improper input string, like "//../foo", or "\\..\foo", the result would be the same value, thus possibly providing access to files in the parent directory, but not further above (thus "limited" path traversal), if the calling code would use the result to construct a path value.

</details>

<details>
<summary> <b>[ CVE-2017-1000487 ] org.codehaus.plexus:plexus-utils 1.5.1</b> </summary>
<br>


**Description:**
Plexus-utils before 3.0.16 is vulnerable to command injection because it does not correctly process the contents of double quoted strings.

</details>

</details>



---
<div align='center'>

[🐸 JFrog Frogbot](https://docs.jfrog-applications.jfrog.io/jfrog-applications/frogbot)

</div>


[comment]: <> (Checksum: 419c0b2f05393b33ccff316fe0d8d5f3)
