### PR TITLE
[🐸 Frogbot] Update version of commons-io:commons-io to 2.7

### DIFF
--- a/multi1/pom.xml
+++ b/multi1/pom.xml
@@ -48,7 +48,7 @@
     </build>
 
     <properties>
-        <my.referenced.version>1.4</my.referenced.version>
+        <my.referenced.version>2.7</my.referenced.version>
     </properties>
 
     <dependencies>


### PR DESCRIPTION
<div align='center'>

[![🚨 This automated pull request was created by Frogbot and fixes the below:](https://raw.githubusercontent.com/jfrog/frogbot/master/resources/v2/vulnerabilitiesFixBannerPR.png)](https://docs.jfrog-applications.jfrog.io/jfrog-applications/frogbot)

</div>


## 📦 Vulnerable Dependencies
### ✍️ Summary
<div align='center'>

| SEVERITY                | CONTEXTUAL ANALYSIS                  | DIRECT DEPENDENCIES                  | IMPACTED DEPENDENCY                  | FIXED VERSIONS                  | CVES                  |
| :---------------------: | :-----------------------------------: | :-----------------------------------: | :-----------------------------------: | :-----------------------------------: | :-----------------------------------: |
| ![](https://raw.githubusercontent.com/jfrog/frogbot/master/resources/v2/applicableMediumSeverity.png)<br>  Medium | Undetermined | commons-io:commons-io:1.4<br>org.jfrog.test:multi1:3.7-SNAPSHOT | commons-io:commons-io 1.4 | [2.7] | CVE-2021-29425 |

</div>

### 🔬 Research Details
**Description:**
In Apache Commons IO before 2.7, When invoking the method FileNameUtils.normalize with an improper input string, like "//../foo", or "\\..\foo", the result would be the same value, thus possibly providing access to files in the parent directory, but not further above (thus "limited" path traversal), if the calling code would use the result to construct a path value.


---
<div align='center'>

[🐸 JFrog Frogbot](https://docs.jfrog-applications.jfrog.io/jfrog-applications/frogbot)

</div>
